### PR TITLE
Node 4, Xcode 7 workaround

### DIFF
--- a/osx/osx.gyp
+++ b/osx/osx.gyp
@@ -9,6 +9,7 @@
 				'-framework', 'Foundation',
 				'-framework', 'CoreData',
 				'-framework', 'Cocoa',
+				'-framework', 'Carbon',
 			  ],
 			},
 			"sources": [


### PR DESCRIPTION
Fix for the issues described here https://github.com/tcr/mediakeys/issues/3 and here https://github.com/nogizhopaboroda/cmus-mediakeys/issues/1

Added carbon framework to osx/osx.gyp
